### PR TITLE
bump gh-scrape version to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitbar",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "text",
   "main": "index.js",
   "scripts": {
@@ -18,6 +18,6 @@
   "homepage": "https://github.com/shikkic/gitbar",
   "dependencies": {
     "dotenv": "^2.0.0",
-    "gh-scrape": "^1.0.10"
+    "gh-scrape": "1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "homepage": "https://github.com/shikkic/gitbar",
   "dependencies": {
     "dotenv": "^2.0.0",
-    "gh-scrape": "1.1.0"
+    "gh-scrape": "1.1.1"
   }
 }


### PR DESCRIPTION
Brings in a new more compatible version of gh-srape. Should get things working again.